### PR TITLE
Ignore ESLint updates on greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - 5
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+
+env:
+  - ESLINT_VERSION=2
+  - ESLINT_VERSION=3
+
+matrix:
+  exclude:
+  - node_js: "0.10"
+    env: ESLINT_VERSION=3
+  - node_js: "0.12"
+    env: ESLINT_VERSION=3
+
+install:
+  - npm install
+  - npm install eslint@$ESLINT_VERSION
 
 deploy:
   provider: npm

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "eslintplugin",
     "chai"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "greenkeeper": {
+    "ignore": ["eslint"]
+  }
 }


### PR DESCRIPTION
Let's use a proper TravisCI build matrix instead to ensure v2 and v3 are supported.