### PR TITLE
Add new rule "no-invalid-terminating-properties"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,18 @@ node_js:
 env:
   - ESLINT_VERSION=2
   - ESLINT_VERSION=3
+  - ESLINT_VERSION=4
 
 matrix:
   exclude:
   - node_js: "0.10"
     env: ESLINT_VERSION=3
+  - node_js: "0.10"
+    env: ESLINT_VERSION=4
   - node_js: "0.12"
     env: ESLINT_VERSION=3
+  - node_js: "0.12"
+    env: ESLINT_VERSION=4
 
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Enable the rules that you would like to use:
 - `no-inner-compare` - Prevent using comparisons in the `expect()` argument
 - `missing-assertion` - Prevent calling `expect(...)` without an assertion like `.to.be.ok`
 - `terminating-properties` - Prevent calling `to.be.ok` and other assertion properties as functions
+- `no-invalid-terminating-properties` - Prevent using invalid terminating properties such as  `to.be.falsy` or `to.be.truthy`
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'no-inner-compare': require('./lib/rules/no-inner-compare'),
     'missing-assertion': require('./lib/rules/missing-assertion'),
-    'terminating-properties': require('./lib/rules/terminating-properties')
+    'terminating-properties': require('./lib/rules/terminating-properties'),
+    'no-invalid-terminating-properties': require('./lib/rules/no-invalid-terminating-properties')
   }
 };

--- a/lib/rules/no-invalid-terminating-properties.js
+++ b/lib/rules/no-invalid-terminating-properties.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var findExpectCall = require('../util/find-expect-call');
+var PROPERTY_TERMINATORS = require('../util/property-terminators');
+
+module.exports = function(context) {
+  return {
+    ExpressionStatement: function(node) {
+      var expression = node.expression;
+
+      if (expression.type !== 'MemberExpression') {
+        return;
+      }
+
+      var property = expression.property;
+      if (property.type !== 'Identifier' || PROPERTY_TERMINATORS.indexOf(property.name) !== -1) {
+        return;
+      }
+
+      var expectCall = findExpectCall(expression);
+      if (!expectCall)
+        return;
+
+      context.report({
+        node: property,
+        message: '"' + property.name + '" is not a valid property'
+      })
+    }
+  };
+};
+
+

--- a/lib/rules/terminating-properties.js
+++ b/lib/rules/terminating-properties.js
@@ -2,16 +2,7 @@
 
 var findExpectCall = require('../util/find-expect-call');
 
-var PROPERTY_TERMINATORS = [
-  'ok',
-  'true',
-  'false',
-  'null',
-  'undefined',
-  'exist',
-  'empty',
-  'arguments'
-];
+var PROPERTY_TERMINATORS = require('../util/property-terminators');
 
 module.exports = function(context) {
   return {

--- a/lib/util/property-terminators.js
+++ b/lib/util/property-terminators.js
@@ -1,0 +1,10 @@
+module.exports = [
+  'ok',
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'exist',
+  'empty',
+  'arguments'
+];

--- a/tests/lib/rules/no-invalid-terminating-properties.js
+++ b/tests/lib/rules/no-invalid-terminating-properties.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var rule = require('../../../lib/rules/no-invalid-terminating-properties');
+var RuleTester = require('eslint').RuleTester;
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-invalid-terminating-properties', rule, {
+  valid: [{
+    code: 'expect(foo).to.be.ok;'
+  }, {
+    code: 'expect(foo).to.be.true;'
+  }, {
+    code: 'expect(foo).to.be.false;'
+  }, {
+    code: 'expect(foo).to.be.null;'
+  }, {
+    code: 'expect(foo).to.be.undefined;'
+  }, {
+    code: 'expect(foo).to.exist;'
+  }, {
+    code: 'expect(foo).to.be.empty;'
+  }, {
+    code: 'expect(foo).to.be.arguments;'
+  }, {
+    code: 'foo(bar).to.be.falsy;'
+  }],
+
+  invalid: [{
+    code: 'expect(foo).to.be.falsy;',
+    errors: [{
+      message: '"falsy" is not a valid property'
+    }]
+  }, {
+    code: 'expect(foo).to.be.truthy;',
+    errors: [{
+      message: '"truthy" is not a valid property'
+    }]
+  }]
+});


### PR DESCRIPTION
Accidentally using undefined terminating properties leads to the expect
check not working as expected. For example,

`expect(foo).to.be.falsy`

results in a no-op that does not perform any check and is probably not
what the author intended. See https://github.com/chaijs/chai/issues/235
for a discussion of `truthy` and `falsy`, including examples of people that
have run into this:
https://github.com/chaijs/chai/issues/235#issuecomment-97992643