### PR TITLE
Add new rule "no-invalid-terminating-properties"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Enable the rules that you would like to use:
 - `no-inner-compare` - Prevent using comparisons in the `expect()` argument
 - `missing-assertion` - Prevent calling `expect(...)` without an assertion like `.to.be.ok`
 - `terminating-properties` - Prevent calling `to.be.ok` and other assertion properties as functions
+- `no-invalid-terminating-properties` - Prevent using invalid terminating properties such as  `to.be.falsy` or `to.be.truthy`
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ Enable the rules that you would like to use:
 - `terminating-properties` - Prevent calling `to.be.ok` and other assertion properties as functions
 - `no-invalid-terminating-properties` - Prevent using invalid terminating properties such as  `to.be.falsy` or `to.be.truthy`
 
+Both `terminating-properties` and `no-invalid-terminating-properties` take an object option with an arrary of *additional*
+properties that you want to be treated as valid (e.g., from chai plugins):
+```json
+{
+  "properties": [
+    "json"
+  ]
+}
+```
+
+Example rule:
+```json
+{
+  "rules": {
+    "chai-expect/terminating-properties": [2, { "properties": [ "json" ] } ]
+  }
+}
+
+```
+
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'no-inner-compare': require('./lib/rules/no-inner-compare'),
     'missing-assertion': require('./lib/rules/missing-assertion'),
-    'terminating-properties': require('./lib/rules/terminating-properties')
+    'terminating-properties': require('./lib/rules/terminating-properties'),
+    'no-invalid-terminating-properties': require('./lib/rules/no-invalid-terminating-properties')
   }
 };

--- a/lib/rules/no-invalid-terminating-properties.js
+++ b/lib/rules/no-invalid-terminating-properties.js
@@ -1,9 +1,11 @@
 "use strict";
 
 var findExpectCall = require('../util/find-expect-call');
-var PROPERTY_TERMINATORS = require('../util/property-terminators');
+var propertyTerminators = require('../util/property-terminators');
 
 module.exports = function(context) {
+  var props = propertyTerminators(context.options);
+
   return {
     ExpressionStatement: function(node) {
       var expression = node.expression;
@@ -13,7 +15,7 @@ module.exports = function(context) {
       }
 
       var property = expression.property;
-      if (property.type !== 'Identifier' || PROPERTY_TERMINATORS.indexOf(property.name) !== -1) {
+      if (property.type !== 'Identifier' || props.indexOf(property.name) !== -1) {
         return;
       }
 
@@ -29,4 +31,4 @@ module.exports = function(context) {
   };
 };
 
-
+module.exports.schema = propertyTerminators.schema;

--- a/lib/rules/no-invalid-terminating-properties.js
+++ b/lib/rules/no-invalid-terminating-properties.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var findExpectCall = require('../util/find-expect-call');
+var PROPERTY_TERMINATORS = require('../util/property-terminators');
+
+module.exports = function(context) {
+  return {
+    ExpressionStatement: function(node) {
+      var expression = node.expression;
+
+      if (expression.type !== 'MemberExpression') {
+        return;
+      }
+
+      var property = expression.property;
+      if (property.type !== 'Identifier' || PROPERTY_TERMINATORS.indexOf(property.name) !== -1) {
+        return;
+      }
+
+      var expectCall = findExpectCall(expression);
+      if (!expectCall)
+        return;
+
+      context.report({
+        node: property,
+        message: '"' + property.name + '" is not a valid property'
+      })
+    }
+  };
+};
+
+

--- a/lib/rules/terminating-properties.js
+++ b/lib/rules/terminating-properties.js
@@ -2,9 +2,11 @@
 
 var findExpectCall = require('../util/find-expect-call');
 
-var PROPERTY_TERMINATORS = require('../util/property-terminators');
+var propertyTerminators = require('../util/property-terminators');
 
 module.exports = function(context) {
+  var props = propertyTerminators(context.options);
+
   return {
     ExpressionStatement: function(node) {
       var expression = node.expression;
@@ -16,7 +18,7 @@ module.exports = function(context) {
         return;
 
       var property = callee.property;
-      if (property.type !== 'Identifier' || PROPERTY_TERMINATORS.indexOf(property.name) === -1)
+      if (property.type !== 'Identifier' || props.indexOf(property.name) === -1)
         return;
 
       var expectCall = findExpectCall(callee.object);
@@ -36,3 +38,5 @@ module.exports = function(context) {
     }
   };
 };
+
+module.exports.schema = propertyTerminators.schema;

--- a/lib/rules/terminating-properties.js
+++ b/lib/rules/terminating-properties.js
@@ -2,16 +2,7 @@
 
 var findExpectCall = require('../util/find-expect-call');
 
-var PROPERTY_TERMINATORS = [
-  'ok',
-  'true',
-  'false',
-  'null',
-  'undefined',
-  'exist',
-  'empty',
-  'arguments'
-];
+var PROPERTY_TERMINATORS = require('../util/property-terminators');
 
 module.exports = function(context) {
   return {

--- a/lib/util/property-terminators.js
+++ b/lib/util/property-terminators.js
@@ -1,4 +1,4 @@
-module.exports = [
+var PROPERTY_TERMINATORS = [
   'ok',
   'true',
   'false',
@@ -7,4 +7,31 @@ module.exports = [
   'exist',
   'empty',
   'arguments'
+];
+
+module.exports = function(options) {
+  var propertyTerminators = PROPERTY_TERMINATORS;
+  var propOptions = options[0];
+  if (propOptions && propOptions.properties) {
+    propertyTerminators = propertyTerminators.concat(propOptions.properties);
+  }
+  return propertyTerminators;
+};
+
+module.exports.schema = [
+  {
+    "type": "object",
+    "properties": {
+      "properties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      }
+    },
+    "required": [ "properties" ],
+    "additionalProperties": false
+  }
 ];

--- a/lib/util/property-terminators.js
+++ b/lib/util/property-terminators.js
@@ -1,0 +1,10 @@
+module.exports = [
+  'ok',
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'exist',
+  'empty',
+  'arguments'
+];

--- a/tests/lib/rules/no-invalid-terminating-properties.js
+++ b/tests/lib/rules/no-invalid-terminating-properties.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var rule = require('../../../lib/rules/no-invalid-terminating-properties');
+var RuleTester = require('eslint').RuleTester;
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-invalid-terminating-properties', rule, {
+  valid: [{
+    code: 'expect(foo).to.be.ok;'
+  }, {
+    code: 'expect(foo).to.be.true;'
+  }, {
+    code: 'expect(foo).to.be.false;'
+  }, {
+    code: 'expect(foo).to.be.null;'
+  }, {
+    code: 'expect(foo).to.be.undefined;'
+  }, {
+    code: 'expect(foo).to.exist;'
+  }, {
+    code: 'expect(foo).to.be.empty;'
+  }, {
+    code: 'expect(foo).to.be.arguments;'
+  }, {
+    code: 'foo(bar).to.be.falsy;'
+  }],
+
+  invalid: [{
+    code: 'expect(foo).to.be.falsy;',
+    errors: [{
+      message: '"falsy" is not a valid property'
+    }]
+  }, {
+    code: 'expect(foo).to.be.truthy;',
+    errors: [{
+      message: '"truthy" is not a valid property'
+    }]
+  }]
+});

--- a/tests/lib/rules/no-invalid-terminating-properties.js
+++ b/tests/lib/rules/no-invalid-terminating-properties.js
@@ -22,6 +22,12 @@ ruleTester.run('no-invalid-terminating-properties', rule, {
   }, {
     code: 'expect(foo).to.be.arguments;'
   }, {
+    code: 'expect(foo).to.be.json;',
+    options: [ {"properties": ["json"] } ]
+  }, {
+    code: 'expect(foo).to.be.html;',
+    options: [ {"properties": ["json", "html"] } ]
+  }, {
     code: 'foo(bar).to.be.falsy;'
   }],
 
@@ -34,6 +40,11 @@ ruleTester.run('no-invalid-terminating-properties', rule, {
     code: 'expect(foo).to.be.truthy;',
     errors: [{
       message: '"truthy" is not a valid property'
+    }]
+  }, {
+    code: 'expect(foo).to.be.json;',
+    errors: [{
+      message: '"json" is not a valid property'
     }]
   }]
 });

--- a/tests/lib/rules/terminating-properties.js
+++ b/tests/lib/rules/terminating-properties.js
@@ -21,6 +21,9 @@ ruleTester.run('terminating-properties', rule, {
     ].join('\n')
   }, {
     code: 'expect(something).to.equal(somethingElse);'
+  }, {
+    code: 'expect(something).to.be.json;',
+    options: [ {"properties": ["json"] } ]
   }],
 
   invalid: [{
@@ -49,6 +52,12 @@ ruleTester.run('terminating-properties', rule, {
     ].join('\n'),
     errors: [{
       message: '"to.exist" used as function'
+    }]
+  }, {
+    code: 'expect(foo).to.be.json()',
+    options: [ {"properties": ["json"] } ],
+    errors: [{
+      message: '"to.be.json" used as function'
     }]
   }]
 });


### PR DESCRIPTION
Accidentally using undefined terminating properties leads to the expect
check not working as expected. For example,

`expect(foo).to.be.falsy`

results in a no-op that does not perform any check and is probably not
what the author intended. See https://github.com/chaijs/chai/issues/235
for a discussion of `truthy` and `falsy`, including examples of people that
have run into this:
https://github.com/chaijs/chai/issues/235#issuecomment-97992643

Updated version of https://github.com/Turbo87/eslint-plugin-chai-expect/pull/20

Also fixes https://github.com/Turbo87/eslint-plugin-chai-expect/issues/18