### PR TITLE
Document terminating-properties rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The terminating-properties rule can be configured to ensure these (or other) add
 ```json
 {
   "rules": {
-    "chai-expect/terminating-properties": [ "error", 1, {
-      properties: ['headers', 'html', 'ip', 'json', 'redirect', 'test']
+    "chai-expect/terminating-properties": ["error", 1, {
+      "properties": ["headers", "html", "ip", "json", "redirect", "test"]
     }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,44 @@ Enable the rules that you would like to use:
 - `terminating-properties` - Prevent calling `to.be.ok` and other assertion properties as functions
 
 
+### Additional configuration
+
+#### terminating-properties rule
+
+A number of extenstions to chai add additional terminating properties.  For example [chai-http](https://github.com/chaijs/chai-http) adds:
+
+ - headers
+ - html
+ - ip
+ - json
+ - redirect
+ - text
+
+The terminating-properties rule can be configured to ensure these (or other) additional properties are not used as functions:
+
+```json
+{
+  "rules": {
+    "chai-expect/terminating-properties": [ "error", 1, {
+      properties: ['headers', 'html', 'ip', 'json', 'redirect', 'test']
+    }]
+  }
+}
+```
+
+```yaml
+rules:
+  "chai-expect/terminating-properties":
+    - 2
+    - properties:
+      - headers
+      - html
+      - ip
+      - json
+      - redirect
+      - text
+```
+
 ## License
 
 eslint-plugin-chai-expect is licensed under the [MIT License](http://www.opensource.org/licenses/mit-license.php).

--- a/README.md
+++ b/README.md
@@ -61,24 +61,11 @@ The terminating-properties rule can be configured to ensure these (or other) add
 ```json
 {
   "rules": {
-    "chai-expect/terminating-properties": ["error", 1, {
+    "chai-expect/terminating-properties": ["error", {
       "properties": ["headers", "html", "ip", "json", "redirect", "test"]
     }]
   }
 }
-```
-
-```yaml
-rules:
-  "chai-expect/terminating-properties":
-    - 2
-    - properties:
-      - headers
-      - html
-      - ip
-      - json
-      - redirect
-      - text
 ```
 
 ## License


### PR DESCRIPTION
Adds some docs for the terminating-properties rule.  

I've tested the yaml config and it works.  I think I've got the correct JSON defined but it might be worth you giving it a quick check.

Related to https://github.com/Turbo87/eslint-plugin-chai-expect/issues/18