### PR TITLE
Fix expect finder utility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "extends": "eslint:recommended",
+  "plugins": [ "mocha" ],
   "env": {
+    "mocha": true,
     "node": true
   },
   "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
   "extends": "eslint:recommended",
-  "plugins": [ "mocha" ],
   "env": {
     "mocha": true,
     "node": true

--- a/lib/util/find-expect-call.js
+++ b/lib/util/find-expect-call.js
@@ -1,6 +1,11 @@
 module.exports = function findExpectCall(node) {
-  if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'expect') {
-    return node;
+  if (node.type === 'CallExpression') {
+    if (node.callee.type === 'Identifier' && node.callee.name === 'expect') {
+      return node;
+    }
+    if (node.callee.type === 'MemberExpression') {
+      return findExpectCall(node.callee.object);
+    }
   }
 
   if (node.type === 'MemberExpression') {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "2.1.0",
-    "eslint-plugin-mocha": "^5.2.0",
+    "espree": "^3.5.4",
     "mocha": "^3.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "homepage": "https://github.com/turbo87/eslint-plugin-chai-expect",
   "bugs": "https://github.com/turbo87/eslint-plugin-chai-expect/issues",
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "2.1.0",
+    "eslint-plugin-mocha": "^5.2.0",
     "mocha": "^3.0.2"
   },
   "keywords": [
@@ -33,6 +35,8 @@
   ],
   "license": "MIT",
   "greenkeeper": {
-    "ignore": ["eslint"]
+    "ignore": [
+      "eslint"
+    ]
   }
 }

--- a/tests/lib/util/find-expect-call.js
+++ b/tests/lib/util/find-expect-call.js
@@ -7,13 +7,14 @@ var findExpectCall = require('../../../lib/util/find-expect-call');
 describe('find-expect-call util', function () {
   it('Finds expect statements which are considered member expressions', function () {
     var code = 'expect(true).to.be.ok;';
-    var ast = espree.parse(code, 'foo.js');
+    var ast = espree.parse(code);
     var result = findExpectCall(ast.body[0].expression);
     expect(result).to.be.an('object');
   });
+
   it('Finds expect statements which are considered recursive call expressions', function () {
     var code = 'expect(true).to.equal(true);';
-    var ast = espree.parse(code, 'foo.js');
+    var ast = espree.parse(code);
     var result = findExpectCall(ast.body[0].expression);
     expect(result).to.be.an('object');
   });

--- a/tests/lib/util/find-expect-call.js
+++ b/tests/lib/util/find-expect-call.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var expect = require('chai').expect;
+var espree = require('espree');
+var findExpectCall = require('../../../lib/util/find-expect-call');
+
+describe('find-expect-call util', function () {
+  it('Finds expect statements which are considered member expressions', function () {
+    var code = 'expect(true).to.be.ok;';
+    var ast = espree.parse(code, 'foo.js');
+    var result = findExpectCall(ast.body[0].expression);
+    expect(result).to.be.an('object');
+  });
+  it('Finds expect statements which are considered recursive call expressions', function () {
+    var code = 'expect(true).to.equal(true);';
+    var ast = espree.parse(code, 'foo.js');
+    var result = findExpectCall(ast.body[0].expression);
+    expect(result).to.be.an('object');
+  });
+});


### PR DESCRIPTION
Attempting to build one of my own custom rules on top of this repo, I found some cases in which the `findExpectCall` function was not accurately finding all expect statements. Particularly ones which had function calls within their assertion chain.

The first commit demonstrates the issue, the second commit solves it.