### PR TITLE
Drop support for Node.js 4 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
+  - "8"
+  - "10"
 
 env:
   - ESLINT_VERSION=2
@@ -13,13 +12,13 @@ env:
 
 matrix:
   exclude:
-  - node_js: "0.10"
+  - node_js: "6"
     env: ESLINT_VERSION=3
-  - node_js: "0.10"
+  - node_js: "6"
     env: ESLINT_VERSION=4
-  - node_js: "0.12"
+  - node_js: "8"
     env: ESLINT_VERSION=3
-  - node_js: "0.12"
+  - node_js: "8"
     env: ESLINT_VERSION=4
 
 install:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "espree": "^3.5.4",
     "mocha": "^3.0.2"
   },
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  },
   "greenkeeper": {
     "ignore": [
       "eslint"


### PR DESCRIPTION
The currently supported Node.js versions are now Node 6, 8 and 10.