### PR TITLE
Add `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+/tests/
+/.editorconfig
+/.eslintignore
+/.eslintrc
+/.gitignore
+/.npmignore
+/.travis.yml
+/yarn.lock


### PR DESCRIPTION
This will remove the `yarn.lock` file from the final bundle which significantly reduces the bundlesize.