### PR TITLE
Add `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,21 @@ Enable the rules that you would like to use:
 ```json
 {
   "rules": {
+    "chai-expect/no-inner-compare": 2,
     "chai-expect/missing-assertion": 2,
-    "chai-expect/terminating-properties": 1
+    "chai-expect/terminating-properties": 2
   }
 }
 ```
 
+Or, if you just want the above defaults, you can avoid all of the above
+and just extend the config:
+
+```json
+{
+  "extends": ["plugin:chai-expect/recommended"]
+}
+```
 
 ## Rules
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
 'use strict';
 
 module.exports = {
+  configs: {
+    recommended: {
+      plugins: ['chai-expect'],
+      rules: {
+        'chai-expect/no-inner-compare': 'error',
+        'chai-expect/missing-assertion': 'error',
+        'chai-expect/terminating-properties': 'error'
+      }
+    }
+  },
   rules: {
     'no-inner-compare': require('./lib/rules/no-inner-compare'),
     'missing-assertion': require('./lib/rules/missing-assertion'),


### PR DESCRIPTION
- Enhancement: Add "recommended" config which auto-adds `plugins` and all current rules (one as a warning); fixes #69
~~- Linting: Rename eslintrc to include recommended extension~~
~~- git/npm: Add package-lock.json to ignored files~~
~~- npm: Add recommended package.json fields (contributors, dependencies)~~
~~- npm: Add `peerDependencies` as called for by ESLint~~
~~- Travis: Add Node 12/ESLint 6 and Node 10/ESLint 5 tests~~

~~Your Travis file tests ESLint 2 and your README insists on a minimum version of 4, so I wasn't sure which one to fix (and thus which to use in the `peerDependencies` field which ESLint calls for).~~

As far as Node version, FWIW, your devDeps `import-from` and `eslint` can both be updated to the latest versions if you move to a minimum version of Node 8.