### PR TITLE
no-inner-compare: Add support for `expect(a != b).to.equal(true)`

### DIFF
--- a/lib/rules/no-inner-compare.js
+++ b/lib/rules/no-inner-compare.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
   return {
     ExpressionStatement: function(node) {
       var expression = node.expression;
-      if (expression.type !== 'MemberExpression')
+      if (expression.type !== 'MemberExpression' && expression.type !== 'CallExpression')
         return;
 
       var expect = findExpectCall(expression);

--- a/tests/lib/rules/no-inner-compare.js
+++ b/tests/lib/rules/no-inner-compare.js
@@ -11,6 +11,8 @@ ruleTester.run('no-inner-compare', rule, {
     code: 'expect(a && b).to.be.ok;'
   }, {
     code: 'expect(a || b).to.be.ok;'
+  }, {
+    code: 'expect(a).to.equal(5);'
   }],
 
   invalid: [{
@@ -30,6 +32,11 @@ ruleTester.run('no-inner-compare', rule, {
     }]
   }, {
     code: 'expect(a >= b).to.be.ok;',
+    errors: [{
+      message: 'operator ">=" used in expect(), use "to.be.at.least()" instead'
+    }]
+  }, {
+    code: 'expect(a >= b).to.equal(true);',
     errors: [{
       message: 'operator ">=" used in expect(), use "to.be.at.least()" instead'
     }]


### PR DESCRIPTION
- Enhancement: Check for inner compare with `CallExpression` type assertions