### PR TITLE
npm: Add recommended package.json fields (contributors, dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "bugs": "https://github.com/turbo87/eslint-plugin-chai-expect/issues",
   "license": "MIT",
   "author": "Tobias Bieniek <tobias.bieniek@gmail.com>",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "files": [
     "LICENSE",
     "README.md",
@@ -28,6 +31,7 @@
     "test": "npm run lint && npm run unit-test",
     "unit-test": "mocha tests/**/*.js"
   },
+  "dependencies": {},
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "5.16.0",


### PR DESCRIPTION
Not a big deal, but I find these helpful for the following reasons:

1. The package.json linter I use in my IDE (Atom) will stop annoying me. :) (I enable it so as to find such items missing on my projects.)
2. `dependencies` can get auto-added by npm under some conditions anyways (IIRC during install).
3. It helps when scanning through the file at a glance to see that there are none.