### PR TITLE
Add `meta.type`

### DIFF
--- a/lib/rules/missing-assertion.js
+++ b/lib/rules/missing-assertion.js
@@ -1,30 +1,35 @@
 'use strict';
 
-module.exports = function(context) {
-  function checkCallee (callee, node) {
-    if (callee.type === 'Identifier' && callee.name === 'expect') {
-      context.report({
-        node,
-        message: 'expect(...) used without assertion'
-      })
-    }
-  }
-  return {
-    ReturnStatement(node) {
-      if (
-        node.argument && node.argument.type === 'CallExpression' &&
-        node.argument.callee
-      ) {
-        checkCallee(node.argument.callee, node.argument);
+module.exports = {
+  meta: {
+    type: 'problem'
+  },
+  create (context) {
+    function checkCallee (callee, node) {
+      if (callee.type === 'Identifier' && callee.name === 'expect') {
+        context.report({
+          node,
+          message: 'expect(...) used without assertion'
+        })
       }
-    },
-    ExpressionStatement(node) {
-      let {expression} = node;
-      if (!expression || expression.type !== 'CallExpression')
-        return;
-
-      let {callee} = expression;
-      checkCallee(callee, node);
     }
-  };
+    return {
+      ReturnStatement(node) {
+        if (
+          node.argument && node.argument.type === 'CallExpression' &&
+          node.argument.callee
+        ) {
+          checkCallee(node.argument.callee, node.argument);
+        }
+      },
+      ExpressionStatement(node) {
+        let {expression} = node;
+        if (!expression || expression.type !== 'CallExpression')
+          return;
+
+        let {callee} = expression;
+        checkCallee(callee, node);
+      }
+    };
+  }
 };

--- a/lib/rules/no-inner-compare.js
+++ b/lib/rules/no-inner-compare.js
@@ -13,43 +13,48 @@ const HINTS = {
   '<=': 'to.be.at.most()'
 };
 
-module.exports = function(context) {
-  let checkMemberOrCallExpression = (expression) => {
-    if (expression.type !== 'MemberExpression' && expression.type !== 'CallExpression')
-      return;
+module.exports = {
+  meta: {
+    type: 'suggestion'
+  },
+  create(context) {
+    let checkMemberOrCallExpression = (expression) => {
+      if (expression.type !== 'MemberExpression' && expression.type !== 'CallExpression')
+        return;
 
-    let expect = findExpectCall(expression);
-    if (!expect)
-      return;
+      let expect = findExpectCall(expression);
+      if (!expect)
+        return;
 
-    let args = expect.arguments;
-    let [firstArgument] = args;
-    if (!firstArgument || firstArgument.type !== 'BinaryExpression')
-      return;
+      let args = expect.arguments;
+      let [firstArgument] = args;
+      if (!firstArgument || firstArgument.type !== 'BinaryExpression')
+        return;
 
-    let hint = HINTS[firstArgument.operator];
-    if (!hint)
-      return;
+      let hint = HINTS[firstArgument.operator];
+      if (!hint)
+        return;
 
-    context.report({
-      node: firstArgument,
-      message: `operator "${firstArgument.operator}" used in expect(), use "${hint}" instead`
-    });
-  };
-  return {
-    ReturnStatement(node) {
-      if (
-        node.argument && node.argument.type === 'CallExpression' &&
-        node.argument.callee
-      ) {
-        checkMemberOrCallExpression(node.argument);
-      } else if (node.argument && node.argument.type === 'MemberExpression') {
-        checkMemberOrCallExpression(node.argument);
+      context.report({
+        node: firstArgument,
+        message: `operator "${firstArgument.operator}" used in expect(), use "${hint}" instead`
+      });
+    };
+    return {
+      ReturnStatement(node) {
+        if (
+          node.argument && node.argument.type === 'CallExpression' &&
+          node.argument.callee
+        ) {
+          checkMemberOrCallExpression(node.argument);
+        } else if (node.argument && node.argument.type === 'MemberExpression') {
+          checkMemberOrCallExpression(node.argument);
+        }
+      },
+      ExpressionStatement(node) {
+        let {expression} = node;
+        checkMemberOrCallExpression(expression);
       }
-    },
-    ExpressionStatement(node) {
-      let {expression} = node;
-      checkMemberOrCallExpression(expression);
-    }
-  };
+    };
+  }
 };

--- a/lib/rules/no-inner-literal.js
+++ b/lib/rules/no-inner-literal.js
@@ -2,58 +2,63 @@
 
 const findExpectCall = require('../util/find-expect-call');
 
-module.exports = function(context) {
-  function checkMemberOrCallExpression (expression) {
-    if (expression.type !== 'MemberExpression' && expression.type !== 'CallExpression')
-      return;
+module.exports = {
+  meta: {
+    type: 'problem'
+  },
+  create (context) {
+    function checkMemberOrCallExpression (expression) {
+      if (expression.type !== 'MemberExpression' && expression.type !== 'CallExpression')
+        return;
 
-    let expect = findExpectCall(expression);
-    if (!expect)
-      return;
+      let expect = findExpectCall(expression);
+      if (!expect)
+        return;
 
-    let args = expect.arguments;
-    let [firstArgument] = args;
-    if (!firstArgument)
-      return;
+      let args = expect.arguments;
+      let [firstArgument] = args;
+      if (!firstArgument)
+        return;
 
-    let value;
-    if (firstArgument.type === 'Literal' || firstArgument.type === 'BigIntLiteral') {
-      value = firstArgument.raw;
-    } else if (firstArgument.type === 'Identifier' && [
-      'undefined', 'NaN', 'Infinity'
-    ].includes(firstArgument.name)) {
-      value = firstArgument.name;
-    } else if (firstArgument.type === 'ThisExpression') {
-      value = 'this';
-    } else if (
-      firstArgument.type === 'UnaryExpression' &&
-      firstArgument.argument.type === 'Identifier' &&
-      firstArgument.argument.name === 'Infinity'
-    ) {
-      value = `${firstArgument.operator}Infinity`;
-    } else {
-      return;
-    }
-
-    context.report({
-      node: firstArgument,
-      message: `\`${value}\` used in expect()`
-    });
-  }
-  return {
-    ReturnStatement(node) {
-      if (
-        node.argument && node.argument.type === 'CallExpression' &&
-        node.argument.callee
+      let value;
+      if (firstArgument.type === 'Literal' || firstArgument.type === 'BigIntLiteral') {
+        value = firstArgument.raw;
+      } else if (firstArgument.type === 'Identifier' && [
+        'undefined', 'NaN', 'Infinity'
+      ].includes(firstArgument.name)) {
+        value = firstArgument.name;
+      } else if (firstArgument.type === 'ThisExpression') {
+        value = 'this';
+      } else if (
+        firstArgument.type === 'UnaryExpression' &&
+        firstArgument.argument.type === 'Identifier' &&
+        firstArgument.argument.name === 'Infinity'
       ) {
-        checkMemberOrCallExpression(node.argument);
-      } else if (node.argument && node.argument.type === 'MemberExpression') {
-        checkMemberOrCallExpression(node.argument);
+        value = `${firstArgument.operator}Infinity`;
+      } else {
+        return;
       }
-    },
-    ExpressionStatement(node) {
-      let {expression} = node;
-      checkMemberOrCallExpression(expression);
+
+      context.report({
+        node: firstArgument,
+        message: `\`${value}\` used in expect()`
+      });
     }
-  };
+    return {
+      ReturnStatement(node) {
+        if (
+          node.argument && node.argument.type === 'CallExpression' &&
+          node.argument.callee
+        ) {
+          checkMemberOrCallExpression(node.argument);
+        } else if (node.argument && node.argument.type === 'MemberExpression') {
+          checkMemberOrCallExpression(node.argument);
+        }
+      },
+      ExpressionStatement(node) {
+        let {expression} = node;
+        checkMemberOrCallExpression(expression);
+      }
+    };
+  }
 };

--- a/lib/rules/terminating-properties.js
+++ b/lib/rules/terminating-properties.js
@@ -13,49 +13,54 @@ const PROPERTY_TERMINATORS = [
   'arguments'
 ];
 
-module.exports = function(context) {
-  let options = context.options[0] || {};
-  let additionalTerminators = options.properties || [];
-  let validTerminators = [...PROPERTY_TERMINATORS, ...additionalTerminators];
+module.exports = {
+  meta: {
+    type: 'problem'
+  },
+  create (context) {
+    let options = context.options[0] || {};
+    let additionalTerminators = options.properties || [];
+    let validTerminators = [...PROPERTY_TERMINATORS, ...additionalTerminators];
 
-  function checkUseAsFunction (expression) {
-    if (expression.type !== 'CallExpression')
-      return;
+    function checkUseAsFunction (expression) {
+      if (expression.type !== 'CallExpression')
+        return;
 
-    let {callee} = expression;
-    if (callee.type !== 'MemberExpression')
-      return;
+      let {callee} = expression;
+      if (callee.type !== 'MemberExpression')
+        return;
 
-    let {property} = callee;
-    if (property.type !== 'Identifier' || !validTerminators.includes(property.name))
-      return;
+      let {property} = callee;
+      if (property.type !== 'Identifier' || !validTerminators.includes(property.name))
+        return;
 
-    let expectCall = findExpectCall(callee.object);
-    if (!expectCall)
-      return;
+      let expectCall = findExpectCall(callee.object);
+      if (!expectCall)
+        return;
 
-    let source = context.getSourceCode();
+      let source = context.getSourceCode();
 
-    let calleeText = source.getText(callee);
-    let expectText = source.getText(expectCall);
-    let assertionText = calleeText.substr(expectText.length + 1);
+      let calleeText = source.getText(callee);
+      let expectText = source.getText(expectCall);
+      let assertionText = calleeText.substr(expectText.length + 1);
 
-    context.report({
-      node: property,
-      message: `"${assertionText}" used as function`
-    });
-  }
-
-  return {
-    ReturnStatement(node) {
-      let {argument} = node;
-      if (argument) {
-        checkUseAsFunction(argument);
-      }
-    },
-    ExpressionStatement (node) {
-      let {expression} = node;
-      checkUseAsFunction(expression);
+      context.report({
+        node: property,
+        message: `"${assertionText}" used as function`
+      });
     }
-  };
+
+    return {
+      ReturnStatement(node) {
+        let {argument} = node;
+        if (argument) {
+          checkUseAsFunction(argument);
+        }
+      },
+      ExpressionStatement (node) {
+        let {expression} = node;
+        checkUseAsFunction(expression);
+      }
+    };
+  }
 };


### PR DESCRIPTION
- Use non-deprecated rule format and add `meta.type`

New rule format introduced at https://eslint.org/blog/2016/07/eslint-new-rule-format

Note that while there are no fixers to utilize `meta.type` (in `--fix-type`), `meta.type` is still usable by formatters (e.g., my [eslint-formatter-badger](https://github.com/brettz9/eslint-formatter-badger), for reporting meta-data on rules).