### PR TITLE
Add support for ESLint@7 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "unit-test": "mocha tests/**/*.js"
   },
   "peerDependencies": {
-    "eslint": ">=2.0.0 <= 6.x"
+    "eslint": ">=2.0.0 <= 7.x"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
The devDependency has already been updated to v7, and the tests and lint all seem to pass with it.