### PR TITLE
Detect missing assertions in an arrow body

### DIFF
--- a/lib/rules/missing-assertion.js
+++ b/lib/rules/missing-assertion.js
@@ -29,7 +29,15 @@ module.exports = {
 
         let {callee} = expression;
         checkCallee(callee, node);
-      }
+      },
+      ArrowFunctionExpression(node) {
+        if (
+          node.body && node.body.type === 'CallExpression' &&
+          node.body.callee
+        ) {
+          checkCallee(node.body.callee, node.body);
+        }
+      },
     };
   }
 };

--- a/tests/lib/rules/missing-assertions.js
+++ b/tests/lib/rules/missing-assertions.js
@@ -29,7 +29,10 @@ ruleTester.run('missing-assertion', rule, {
         return expect(true).to.be.ok();
       });
     `
-  }],
+  }, {
+    code: 'it("works as expected", () => expect(true).to.be.true);',
+    parserOptions: { ecmaVersion: 6 },
+  } ],
 
   invalid: [{
     code: `
@@ -46,6 +49,12 @@ ruleTester.run('missing-assertion', rule, {
         return expect(true);
       });
     `,
+    errors: [{
+      message: 'expect(...) used without assertion'
+    }]
+  }, {
+    code: 'it("fails as expected", () => expect(true));',
+    parserOptions: { ecmaVersion: 6 },
     errors: [{
       message: 'expect(...) used without assertion'
     }]


### PR DESCRIPTION
I stumbled upon a project that was missing `expect` assertions and tried to use `eslint-plugin-chai-expect` to find all occurrences but due to the way they wrote some of their tests (https://github.com/codeceptjs/CodeceptJS/blob/04739e52ddd725fc516a691b77ec37d4f9cbc3f5/test/unit/utils_test.js#L10-L11), some missing assertions were not detected:

```js
    it('exists', () => expect(utils.fileExists(__filename)));
    it('not exists', () => expect(!utils.fileExists('not_utils.js')));
```

The use of `expect(…)` as the body of an arrow function, although unusual, does not seem invalid to me and I think it would be helpful if `eslint-plugin-chai-expect` would detect missing assertions in such a case as well.

So here's a PR that hopefully adds just this.