### PR TITLE
Add ESLint flat config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ESLint plugin that checks for common chai.js `expect()` mistakes
 
+> [!IMPORTANT]
+> The `recommended` preset is for the ESLint legacy configuration system
+> (`.eslintrc.json`). The `recommended-flat` configuration is for the new flat
+> configuration system.
 
 ## Requirements
 
@@ -19,6 +23,8 @@ npm install --save-dev eslint-plugin-chai-expect
 
 
 ## Configuration
+
+### Legacy ESLint Configuration Format (.eslintrc.json)
 
 Add a `plugins` section and specify `chai-expect` as a plugin:
 
@@ -50,6 +56,42 @@ and just extend the config:
 {
   "extends": ["plugin:chai-expect/recommended"]
 }
+```
+
+### Flat ESLint Configuration Format (eslint.config.js)
+
+Add a `plugins` section and specify `chai-expect` as a plugin and enable the rules that you would like to use:
+
+```js
+import chaiExpectPlugin from 'eslint-plugin-chai-expect';
+
+export default [
+  {
+    "plugins": {
+      "chai-expect": chaiExpectPlugin
+    },
+    "rules": {
+      "chai-expect/no-inner-compare": 2,
+      "chai-expect/no-inner-literal": 2,
+      "chai-expect/missing-assertion": 2,
+      "chai-expect/terminating-properties": 2
+    }
+  }
+];
+```
+
+Or, if you just want the above defaults, you can avoid all of the above
+and just extend the config:
+
+```js
+import chaiExpectPlugin from 'eslint-plugin-chai-expect';
+
+export default [
+  chaiExpectPlugin.configs["recommended-flat"],
+  {
+    // ...
+  },
+];
 ```
 
 ## Rules

--- a/index.js
+++ b/index.js
@@ -1,21 +1,39 @@
 'use strict';
 
-module.exports = {
-  configs: {
-    recommended: {
-      plugins: ['chai-expect'],
-      rules: {
-        'chai-expect/no-inner-compare': 'error',
-        'chai-expect/no-inner-literal': 'error',
-        'chai-expect/missing-assertion': 'error',
-        'chai-expect/terminating-properties': 'error'
-      }
-    }
+const pkg = require('./package.json');
+
+let recommendedRules = {
+  'chai-expect/no-inner-compare': 'error',
+  'chai-expect/no-inner-literal': 'error',
+  'chai-expect/missing-assertion': 'error',
+  'chai-expect/terminating-properties': 'error',
+};
+
+const plugin = {
+  meta: {
+    name: pkg.name,
+    version: pkg.version,
   },
+  configs: {},
   rules: {
     'no-inner-compare': require('./lib/rules/no-inner-compare'),
     'no-inner-literal': require('./lib/rules/no-inner-literal'),
     'missing-assertion': require('./lib/rules/missing-assertion'),
     'terminating-properties': require('./lib/rules/terminating-properties')
-  }
+  },
+  processors: {}
 };
+
+plugin.configs['recommended'] = {
+  plugins: ['chai-expect'],
+  rules: recommendedRules,
+};
+
+plugin.configs['recommended-flat'] = {
+  plugins: {
+    'chai-expect': plugin,
+  },
+  rules: recommendedRules,
+};
+
+module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "unit-test": "nyc mocha tests/**/*.js"
   },
   "peerDependencies": {
-    "eslint": ">=2.0.0 <= 8.x"
+    "eslint": ">=2.0.0 <= 9.x"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Added support for eslint 'legacy' and 'flat' configuration files.

~The `recommended` configuration is used for the new flat configuration. The recommended configuration for the legacy system is renamed to `recommended-legacy` (as recommended by the eslint documentation).~

(see https://github.com/Turbo87/eslint-plugin-chai-expect/pull/378#issuecomment-2164924583)

