### PR TITLE
Fix: Prevent renovate to update to latest major releases of 'eslint' and 'chai'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,14 @@
       "matchCurrentVersion": ">= 1.0.0",
       "updateTypes": ["minor"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "/^8\\.[0-9]+\\.[0-9]+$/"
+    },
+    {
+      "matchPackageNames": ["chai"],
+      "allowedVersions": "/^4\\.[0-9]+\\.[0-9]+$/"
     }
   ]
 }


### PR DESCRIPTION
Renovate wants to update chai to v5 and eslint to v9. Both changes would require more modifications than just updating the dependencies and the lock file.

1. Chai@v5 is an esm only package (was a breaking change). To update to this version would require to switch this plugin to esm.
2. eslint@9.x switched to flat configuration files as default. To update to this version would require to change from 'legacy' to 'flat' configuration.

So the idea of this pr is to defer these updates until the project is ready for these modifications.