### PR TITLE
Adjust test suite to be compatible with ESLint 9

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": "eslint:recommended",
-  "parserOptions": { "ecmaVersion": 6 },
+  "parserOptions": { "ecmaVersion": 2018 },
   "env": {
     "mocha": true,
     "node": true

--- a/tests/lib/rules/missing-assertions.js
+++ b/tests/lib/rules/missing-assertions.js
@@ -2,6 +2,7 @@
 
 const rule = require('../../../lib/rules/missing-assertion');
 const {RuleTester} = require('eslint');
+const {ecmaVersion} = require('./utils');
 
 let ruleTester = new RuleTester();
 ruleTester.run('missing-assertion', rule, {
@@ -31,7 +32,7 @@ ruleTester.run('missing-assertion', rule, {
     `
   }, {
     code: 'it("works as expected", () => expect(true).to.be.true);',
-    parserOptions: { ecmaVersion: 6 },
+    ...ecmaVersion(6),
   } ],
 
   invalid: [{
@@ -54,7 +55,7 @@ ruleTester.run('missing-assertion', rule, {
     }]
   }, {
     code: 'it("fails as expected", () => expect(true));',
-    parserOptions: { ecmaVersion: 6 },
+    ...ecmaVersion(6),
     errors: [{
       message: 'expect(...) used without assertion'
     }]

--- a/tests/lib/rules/no-inner-literal.js
+++ b/tests/lib/rules/no-inner-literal.js
@@ -2,6 +2,7 @@
 
 const rule = require('../../../lib/rules/no-inner-literal');
 const {RuleTester} = require('eslint');
+const {ecmaVersion} = require('./utils');
 
 let ruleTester = new RuleTester();
 ruleTester.run('no-inner-literal', rule, {
@@ -19,14 +20,10 @@ ruleTester.run('no-inner-literal', rule, {
     code: 'expect(a).to.equal(5);'
   }, {
     code: 'expect(`template literal`).to.equal(5);',
-    parserOptions: {
-      ecmaVersion: 2015
-    }
+    ...ecmaVersion(2015),
   }, {
     code: 'expect(tagged`template literal`).to.equal(5);',
-    parserOptions: {
-      ecmaVersion: 2015
-    }
+    ...ecmaVersion(2015),
   }, {
     code: `
       it('should have no problems', function () {
@@ -130,8 +127,6 @@ ruleTester.run('no-inner-literal', rule, {
     errors: [{
       message: '`132n` used in expect()'
     }],
-    parserOptions: {
-      ecmaVersion: 2020
-    }
+    ...ecmaVersion(2020),
   }]]
 });

--- a/tests/lib/rules/utils.js
+++ b/tests/lib/rules/utils.js
@@ -1,0 +1,11 @@
+function ecmaVersion(version) {
+  return {
+    parserOptions: {
+      ecmaVersion: version
+    }
+  }
+}
+
+module.exports = {
+  ecmaVersion
+};

--- a/tests/lib/rules/utils.js
+++ b/tests/lib/rules/utils.js
@@ -1,4 +1,16 @@
+const eslintPkg = require('eslint/package.json');
+
+const USE_LANGUAGE_OPTIONS = eslintPkg.version.startsWith('9.');
+
 function ecmaVersion(version) {
+  if (USE_LANGUAGE_OPTIONS) {
+    return {
+      languageOptions: {
+        ecmaVersion: version
+      }
+    };
+  }
+
   return {
     parserOptions: {
       ecmaVersion: version


### PR DESCRIPTION
ESLint 9 moved the `ecmaVersion` property from the `parserOptions` object to a new `languageOptions` object. In this PR we extract an `ecmaVersion()` function that automatically returns the right thing based on `version` in the `eslint/package.json` file.