### PR TITLE
recommended-flat: add `name` field (for tooling)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const pkg = require('./package.json');
 
-let recommendedRules = {
+const recommendedRules = {
   'chai-expect/no-inner-compare': 'error',
   'chai-expect/no-inner-literal': 'error',
   'chai-expect/missing-assertion': 'error',
@@ -30,6 +30,7 @@ plugin.configs['recommended'] = {
 };
 
 plugin.configs['recommended-flat'] = {
+  name: 'chai-expect/recommended-flat',
   plugins: {
     'chai-expect': plugin,
   },


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

I did not add it to the older, non-flat config because it will err there.

I also changed a `let` to a `const` (which didn't need to be a `let`).